### PR TITLE
proposal: add support for nested entity identifiers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,4 @@ module github.com/utilitywarehouse/protoc-gen-uwentity
 
 go 1.16
 
-require (
-	github.com/pkg/errors v0.9.1
-	google.golang.org/protobuf v1.27.1
-)
+require google.golang.org/protobuf v1.27.1

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,6 @@
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=

--- a/main.go
+++ b/main.go
@@ -1,10 +1,10 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
-	"github.com/pkg/errors"
 	"google.golang.org/protobuf/compiler/protogen"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
@@ -13,13 +13,15 @@ import (
 	entitypb "github.com/utilitywarehouse/protoc-gen-uwentity/gen/uw/entity/v1"
 )
 
+var (
+	errIdentifierNotFound = errors.New("identifier not found")
+	errUnsupportedField   = errors.New("unsupported field type")
+)
+
 var tmpl = `
 // GetEntityIdentifier returns the value from the field marked as the identifier
 func (m *%s) GetEntityIdentifier() string {
-	if m != nil {
-		return m.%s
-	}
-	return ""
+	return m.%s
 }
 `
 
@@ -28,8 +30,10 @@ func (m *%s) GetEntityIdentifier() string {
 var paramEnforceDirs []string
 
 type identifier struct {
-	Msg        *protogen.Message
-	Identifier *protogen.Field
+	// the Message that the GetEntityIdentifier method will be added to
+	message string
+	// the Field on the message which should be used as the identifier
+	identifier string
 }
 
 func main() {
@@ -39,7 +43,7 @@ func main() {
 			case "enforce-dir":
 				paramEnforceDirs = append(paramEnforceDirs, value)
 			default:
-				return errors.Errorf("invalid param: %s", name)
+				return fmt.Errorf("invalid param: %s", name)
 			}
 			return nil
 		},
@@ -66,46 +70,36 @@ func main() {
 					continue
 				}
 
-				var hasEntityIdentifier bool
-
-				for _, field := range msg.Fields {
-					// Skip field that don't have `uw.entity.v1.identifer = true`
-					fieldopts := field.Desc.Options().(*descriptorpb.FieldOptions)
-					if !proto.GetExtension(fieldopts, entitypb.E_Identifier).(bool) {
-						continue
-					}
-
-					idents = append(idents, identifier{
-						Msg:        msg,
-						Identifier: field,
-					})
-
-					hasEntityIdentifier = true
-					break
-				}
-
-				// Check that each event has set the identifier
-				// Pass `enforce-dir=<path>` to only check these directories & skip others
-				// Set message option `(uw.entity.v1.ignore) = true` to skip an individual message
-				if !hasEntityIdentifier && strings.HasSuffix(msg.GoIdent.GoName, "Event") {
-					if len(paramEnforceDirs) > 0 {
-						var skipEnforce bool
-						for _, dir := range paramEnforceDirs {
-							if !strings.HasPrefix(file.Desc.Path(), dir) {
-								skipEnforce = true
-								break
+				messageIdentifier, err := getMessageIdentifier(string(msg.Desc.Name()), msg)
+				switch {
+				default:
+					return err
+				case errors.Is(err, nil):
+					idents = append(idents, messageIdentifier)
+				case errors.Is(err, errIdentifierNotFound):
+					// Check that each event has set the identifier
+					// Pass `enforce-dir=<path>` to only check these directories & skip others
+					// Set message option `(uw.entity.v1.ignore) = true` to skip an individual message
+					if strings.HasSuffix(msg.GoIdent.GoName, "Event") {
+						if len(paramEnforceDirs) > 0 {
+							var skipEnforce bool
+							for _, dir := range paramEnforceDirs {
+								if !strings.HasPrefix(file.Desc.Path(), dir) {
+									skipEnforce = true
+									break
+								}
+							}
+							if skipEnforce {
+								continue
 							}
 						}
-						if skipEnforce {
-							continue
-						}
-					}
 
-					return errors.Errorf(
-						"%s/%s: `uw.entity.v1.identifier` not set on event",
-						file.Desc.Path(),
-						msg.GoIdent.GoName,
-					)
+						return fmt.Errorf(
+							"%s/%s: `uw.entity.v1.identifier` not set on event",
+							file.Desc.Path(),
+							msg.GoIdent.GoName,
+						)
+					}
 				}
 			}
 
@@ -117,17 +111,44 @@ func main() {
 
 			// output identifier accessing methods, checking that we support the field type
 			for _, ident := range idents {
-				switch ident.Identifier.Desc.Kind() {
-				case protoreflect.StringKind:
-					output.P(fmt.Sprintf(tmpl, ident.Msg.Desc.Name(), ident.Identifier.GoName))
-				case protoreflect.EnumKind:
-					output.P(fmt.Sprintf(tmpl, ident.Msg.Desc.Name(), ident.Identifier.GoName+".String()"))
-				default:
-					return errors.Errorf("unsupported field type on %s: %s", ident.Msg.Desc.Name(), ident.Identifier.Desc.Kind())
-				}
+				output.P(fmt.Sprintf(tmpl, ident.message, ident.identifier))
 			}
 		}
 
 		return nil
 	})
+}
+
+func getMessageIdentifier(entity string, msg *protogen.Message, fields ...string) (identifier, error) {
+	for _, field := range msg.Fields {
+		// Skip field that don't have `uw.entity.v1.identifer = true`
+		fieldopts := field.Desc.Options().(*descriptorpb.FieldOptions)
+
+		if !proto.GetExtension(fieldopts, entitypb.E_Identifier).(bool) {
+			continue
+		}
+
+		if field.Desc.Cardinality() == protoreflect.Repeated {
+			return identifier{}, fmt.Errorf("repeated fields are not supported on %s: %s: %w", entity, field.Desc.Kind(), errUnsupportedField)
+		}
+
+		var value string
+		switch field.Desc.Kind() {
+		case protoreflect.StringKind:
+			value = fmt.Sprintf("Get%s()", field.GoName)
+		case protoreflect.EnumKind:
+			value = fmt.Sprintf("Get%s().String()", field.GoName)
+		case protoreflect.MessageKind:
+			return getMessageIdentifier(entity, field.Message, append(fields, fmt.Sprintf("Get%s()", field.GoName))...)
+		default:
+			return identifier{}, fmt.Errorf("unsupported field type on %s: %s: %w", entity, field.Desc.Kind(), errUnsupportedField)
+		}
+
+		return identifier{
+			message:    entity,
+			identifier: strings.Join(append(fields, value), "."),
+		}, nil
+	}
+
+	return identifier{}, errIdentifierNotFound
 }


### PR DESCRIPTION
This proposal introduces the ability to assign entity identifiers on nested protobuf messages.

Specifically, given  the following protobuf message:

```protobuf
message MyEvent {
  message Foo {
    message Bar {
      string id = 1 [(uw.entity.v1.identifier) = true];
    }
    Bar bar = 1 [(uw.entity.v1.identifier) = true];
  }
  Foo foo = 1 [(uw.entity.v1.identifier) = true];
}

```

It generates a `GetEntityIdentifier()` method on the `MyEvent` message such as:

```golang
// GetEntityIdentifier returns the value from the field marked as the identifier
func (m *MyEvent) GetEntityIdentifier() string {
	return m.GetFoo().GetBar().GetId()
}
```

A few other changes introduces here:

- Removal of redundant `pkg/errors` import
- Hard error when adding identifier option on a repeated field
- Simplified the `GetEntityIdentifier` by calling the generated Getter method rather than the property directly meaning we can avoid the `nil` check as it is done for us.

## Consideration

I was torn whether to use the existing `identifier` option, or whether to introduce a new one. While this does work, it does feel a bit too magical so definitely open to suggestion on alternative approaches.