### PR TITLE
Use GoName for message identifier

### DIFF
--- a/main.go
+++ b/main.go
@@ -73,7 +73,7 @@ func main() {
 					continue
 				}
 
-				messageIdentifier, err := getMessageIdentifier(string(msg.Desc.Name()), msg)
+				messageIdentifier, err := getMessageIdentifier(msg.GoIdent.GoName, msg)
 				switch {
 				default:
 					return err


### PR DESCRIPTION
This PR changes the message identifier to be `GoName` instead of `Desc.Name()`. In most cases this should yield the same result, but some other cases have different casing.

For example, if the message is named `Card3dsEnrollmentSuccessEvent`, `Desc.Name()` yields exactly that, but whereas `GoName` is `Card3DsEnrollmentSuccessEvent`, which should be the correct identifier to use for the receiver of `GetEntityIdentifier`.