### PR TITLE
sets staff group as owners of this repository

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @utilitywarehouse/staff-group


### PR DESCRIPTION
no team owns this repository at the moment while it's used across all teams